### PR TITLE
Cannot assume result will be defined in certain cases, 

### DIFF
--- a/lib/aggregation.js
+++ b/lib/aggregation.js
@@ -52,7 +52,7 @@ Aggregation.prototype.parse = function (result) {
         case 'missing':
         case 'value_count':
         case 'bucket_script':
-            return result.value;
+            return _.get(result, 'value');
         default:
             return result;
     }


### PR DESCRIPTION
like bucket_script handling an error or missing data