### PR TITLE
i5-3789 - Traverse Elasticsearch query strings for date keywords and replace them.

### DIFF
--- a/lib/date-keywords.js
+++ b/lib/date-keywords.js
@@ -1,0 +1,182 @@
+'use strict';
+
+const moment = require('moment-timezone');
+const _ = require('lodash');
+
+function DateKeywords (dateKeyword) {
+
+    const tz = {
+        transform: function (input, timezone) {
+            const date = _.isString(input) ? moment(input).toDate() : input;
+            const str = moment(date).format('YYYY-MM-DD');
+            // must be in format tz(str, timezone) and NOT moment(str).tz(timezone). the latter adjusts the date
+            return moment.tz(str, timezone);
+        },
+        effective: dateKeyword.tz
+    };
+
+    const parser = function (param) {
+        const operator = param.replace(/[^+\-]+/g, '');
+        const number = operator && operator !== '+' ? '-' + param.replace(/[^0-9]+/g, '') : param.replace(/[^0-9]+/g, '');
+        const unit = operator ? param.split(operator)[1].replace(/[^a-zA-Z]/g, '') : '';
+        return {
+            unit: unit,
+            number: Number(number)
+        };
+    };
+    const makeDate = function (date) {
+        return tz.transform(date, tz.effective);
+    };
+    const keywords = {
+        NOW: function (param) {
+            if (!param) return moment();
+            const info = parser(param);
+            return moment().add(info.number, info.unit || 'd');
+        },
+        TODAY: function (param) {
+            if (!param) return makeDate(moment());
+            const info = parser(param);
+            return makeDate(moment()).add(info.number, info.unit || 'd');
+        },
+        YESTERDAY: function (param) {
+            if (!param) return makeDate(moment()).add(-1, 'd');
+            const info = parser(param);
+            return makeDate(moment()).add(-1, 'd').add(info.number, info.unit || 'd');
+        },
+        MONTH_BEGIN: function (param) {
+            const date = new Date();
+            if (!param) return tz.transform(new Date(date.getFullYear(), date.getMonth(), 1), tz.effective);
+            const info = parser(param);
+            return tz.transform(new Date(date.getFullYear(), date.getMonth(), 1), tz.effective).add(info.number, info.unit || 'M');
+        },
+        MONTH_END: function (param) {
+            const date = new Date();
+            if (!param) return tz.transform(new Date(date.getFullYear(), date.getMonth() + 1, 0), tz.effective);
+            const info = parser(param);
+            if (!info.unit || info.unit.toUpperCase() === 'MONTH' || info.unit === 'M')
+                return tz.transform(new Date(date.getFullYear(), date.getMonth(), 1), tz.effective).add(Number(info.number) + 1, 'M').add(-1, 'd');
+            return tz.transform(new Date(date.getFullYear(), date.getMonth() + 1, 0), tz.effective).add(info.number, info.unit || 'M');
+        },
+        YEAR_BEGIN: function (param) {
+            const date = new Date();
+            if (!param) return tz.transform(new Date(date.getFullYear()), tz.effective);
+            const info = parser(param);
+            return tz.transform(new Date(date.getFullYear(), 0, 1), tz.effective).add(info.number, info.unit || 'year');
+        },
+        YEAR_END: function (param) {
+            const date = new Date();
+            if (!param) return tz.transform(new Date(date.getFullYear(), 11, 31), tz.effective);
+            const info = parser(param);
+            return tz.transform(new Date(date.getFullYear(), 11, 31), tz.effective).add(info.number, info.unit || 'year');
+        },
+        QTR_BEGIN: function (param) {
+            const date = new Date();
+            let date2 = moment();
+            switch (date.getMonth()) {
+                case 0:
+                case 1:
+                case 2:
+                    date2 = tz.transform(date.getFullYear() + '-01-01', tz.effective);
+                    break;
+                case 3:
+                case 4:
+                case 5:
+                    date2 = tz.transform(date.getFullYear() + '-04-01', tz.effective);
+                    break;
+                case 6:
+                case 7:
+                case 8:
+                    date2 = tz.transform(date.getFullYear() + '-07-01', tz.effective);
+                    break;
+                default:
+                    date2 = tz.transform(date.getFullYear() + '-10-01', tz.effective);
+                    break;
+            }
+            if (!param) return date2;
+            const info = parser(param);
+            return date2.add(info.number, info.unit || 'Q');
+        },
+        QTR_END: function (param) {
+            const date = new Date();
+            let date2 = moment();
+            switch (date.getMonth()) {
+                case 0:
+                case 1:
+                case 2:
+                    date2 = tz.transform(date.getFullYear() + '-03-31', tz.effective);
+                    break;
+                case 3:
+                case 4:
+                case 5:
+                    date2 = tz.transform(date.getFullYear() + '-06-30', tz.effective);
+                    break;
+                case 6:
+                case 7:
+                case 8:
+                    date2 = tz.transform(date.getFullYear() + '-09-30', tz.effective);
+                    break;
+                default:
+                    date2 = tz.transform(date.getFullYear() + '-12-31', tz.effective);
+                    break;
+            }
+            if (!param) return date2;
+            const info = parser(param);
+            return date2.add(info.number, info.unit || 'Q');
+        },
+        MONTH_AGO: function (param) {
+            const date = new Date();
+            if (!param) return tz.transform(new Date(date.getFullYear(), date.getMonth() - 1, date.getDate()), tz.effective);
+            const info = parser(param);
+            return tz.transform(moment({
+                year: date.getFullYear(),
+                month: date.getMonth(),
+                day: date.getDate()
+            }).add(-1, 'month'), tz.effective).add(info.number, info.unit || 'M');
+        },
+        MONTH_FROM_NOW: function (param) {
+            const date = new Date();
+            if (!param) return tz.transform(new Date(date.getFullYear(), date.getMonth() + 1, date.getDate()), tz.effective);
+            const info = parser(param);
+            return tz.transform(moment({
+                year: date.getFullYear(),
+                month: date.getMonth(),
+                day: date.getDate()
+            }).add(1, 'month'), tz.effective).add(info.number, info.unit || 'M');
+        },
+        YEAR_AGO: function (param) {
+            const date = new Date();
+            if (!param) return tz.transform(new Date(date.getFullYear() - 1, date.getMonth(), date.getDate()), tz.effective);
+            const info = parser(param);
+            return tz.transform(moment({
+                year: date.getFullYear(),
+                month: date.getMonth(),
+                day: date.getDate()
+            }).add(-1, 'year'), tz.effective).add(info.number, info.unit || 'year');
+        },
+        YEAR_FROM_NOW: function (param) {
+            const date = new Date();
+            if (!param) return tz.transform(new Date(date.getFullYear() + 1, date.getMonth(), date.getDate()), tz.effective);
+            const info = parser(param);
+            return tz.transform(moment({
+                year: date.getFullYear(),
+                month: date.getMonth(),
+                day: date.getDate()
+            }).add(1, 'year'), tz.effective).add(info.number, info.unit || 'year');
+        }
+    };
+
+    const parse = function (v) {
+        v = v.replace(/\s/g, '').toUpperCase();
+        if (v.split('+').length > 1)
+            return keywords[v.split('+')[0]](v);
+        else if (v.split('-').length > 1)
+            return keywords[v.split('-')[0]](v);
+        else
+            return keywords[v]();
+    };
+
+    return parse(dateKeyword.value);
+
+}
+
+exports.DateKeywords = DateKeywords;

--- a/lib/elastic-query-traverser.js
+++ b/lib/elastic-query-traverser.js
@@ -1,0 +1,60 @@
+'use strict';
+const _ = require('lodash');
+const euDateKeywords = require('./date-keywords').DateKeywords;
+
+function ElasticQueryTraverser (query, dateKeywords = euDateKeywords){
+    this.query = query;
+    this.dateKeywords = dateKeywords;
+}
+
+ElasticQueryTraverser.prototype.traverseFilter = function (){
+    return this.traverse(this.query);
+};
+
+ElasticQueryTraverser.prototype.traverse = function (query){
+    if (_.get(query, 'date_keyword') && _.get(query, 'date_keyword.tz')) {
+        const translated = this.dateKeywords(query.date_keyword);
+        const aDay = 86400000;
+        const updateQuery = (info) => {
+            const date = _.isDate(translated) ? translated : new Date(translated);
+            const offset = date.getTime();
+            switch (info.operator) {
+                case 'eq':
+                    return {
+                        gte: offset,
+                        lt: offset + aDay
+                    };
+                case 'gt':
+                    return {
+                        gt: offset + aDay - 1
+                    };
+                case 'gte':
+                    return {
+                        gte: offset
+                    };
+                case 'lt':
+                    return {
+                        lte: offset
+                    };
+                case 'lte':
+                    return {
+                        lte: offset + aDay - 1
+                    };
+            }
+        };
+        query = updateQuery(query.date_keyword);
+    }
+    if (_.isPlainObject(query)) {
+        _.forEach(_.keys(query), (k) => {
+            query[k] = this.traverse(query[k]);
+        });
+    }
+    if (_.isArray(query)) {
+        _.forEach(query, (n, i) => {
+            query[i] = this.traverse(n);
+        });
+    }
+    return query;
+};
+
+exports.ElasticQueryTraverser = ElasticQueryTraverser;

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,6 +73,8 @@ exports.jsonPatchSchema = require('./json-patch-schema');
 
 exports.Aggregation = require('./aggregation').Aggregation;
 exports.AggregateExpression = require('./aggregate-expression').AggregateExpression;
+exports.ElasticQueryTraverser = require('./elastic-query-traverser').ElasticQueryTraverser;
+exports.DateKeywords = require('./date-keywords').DateKeywords;
 
 exports.exists = function (value, exception) {
     if (_.isNull(value) || _.isUndefined(value)) throw exception;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "gulp-tag-version": "^1.2.1",
     "jshint-stylish": "^1.0.1",
     "mocha": "^2.2.1",
+    "moment": "^2.11.0",
+    "moment-timezone": "^0.5.20",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0"
   },

--- a/test/elastic-query-traverser-spec.js
+++ b/test/elastic-query-traverser-spec.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var chai = require('chai');
+var should = chai.should();
+var sinon = require('sinon');
+chai.use(require('sinon-chai'));
+var ElasticQueryTraverser = require('../lib/elastic-query-traverser').ElasticQueryTraverser;
+const moment = require('moment-timezone');
+
+describe('query traverser', function () {
+
+    describe('when a query has date keywords', function () {
+
+        it('should correctly translate the date keyword to an elastic search range filter', function () {
+            var query = {
+                "filter": {
+                    "bool": {
+                        "must": [{
+                            "bool": {
+                                "must": [{
+                                    "range": {
+                                        "OrderDate": {
+                                            "date_keyword": {
+                                                "value": "TODAY-30Y",
+                                                "operator": "lt",
+                                                "tz": "Africa/Abidjan"
+                                            }
+                                        }
+                                    }
+                                }]
+                            }
+                        }]
+                    }
+                }
+            };
+            var expectedQuery = {
+                "filter": {
+                    "bool": {
+                        "must": [{
+                            "bool": {
+                                "must": [{
+                                    "range": {
+                                        "OrderDate": {
+                                            lte: moment.tz(moment(), 'Africa/Abidjan').startOf('day').add(-30, 'years').toDate().getTime()
+                                        }
+                                    }
+                                }]
+                            }
+                        }]
+                    }
+                }
+            };
+            var EQT = new ElasticQueryTraverser(query);
+            var result = EQT.traverseFilter();
+            result.should.deep.equal(expectedQuery);
+        });
+    });
+
+});


### PR DESCRIPTION
https://github.com/entrinsik-org/i5/pull/3295